### PR TITLE
default log level to info so first log line isn't parse error

### DIFF
--- a/cmd/crd-migrator/main.go
+++ b/cmd/crd-migrator/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -15,8 +16,9 @@ import (
 
 func main() {
 	options := internal.Options{
-		QPS:   float32(50.0),
-		Burst: 100,
+		LogLevel: logrus.InfoLevel.String(),
+		QPS:      float32(50.0),
+		Burst:    100,
 	}
 
 	pflag.StringVar(&options.LogLevel, "log-level", options.LogLevel, "log level")


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Currently the tool always shows an error at the top of the log output since there's no default log level.  Default to info so we don't get an immediate error log in the normal case.

@nrb @carlisia 