### PR TITLE
support limit resources for migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /crd-migrator
 
 dist/
+.idea

--- a/cmd/crd-migrator/main.go
+++ b/cmd/crd-migrator/main.go
@@ -4,8 +4,11 @@
 package main
 
 import (
+	context2 "context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -39,9 +42,7 @@ func main() {
 		pflag.PrintDefaults()
 		os.Exit(0)
 	}
-	resourceSet := internal.New(options.Resources,",")
-	if nil == resourceSet{
-		internal.NewMigrator(options).MigrateAllResources()
-	}
-	internal.NewMigrator(options).MigrateSomeResources(resourceSet)
+	context := context2.Background()
+	go wait.Until(internal.NewMigrator(options).MigrateSomeResources, 2 * time.Second, context.Done())
+	<-context.Done()
 }

--- a/cmd/crd-migrator/main.go
+++ b/cmd/crd-migrator/main.go
@@ -20,7 +20,7 @@ func main() {
 		QPS:      float32(50.0),
 		Burst:    100,
 	}
-
+	pflag.StringVar(&options.Resources, "resources", options.LogLevel, "limit resource for migration,use plural name,separator:, e.g: pods,jobs")
 	pflag.StringVar(&options.LogLevel, "log-level", options.LogLevel, "log level")
 	pflag.StringVar(&options.Kubeconfig, "kubeconfig", options.Kubeconfig, "path to kubeconfig file")
 	pflag.StringVar(&options.Context, "context", options.Context, "specific context to use in the kubeconfig file")
@@ -39,6 +39,9 @@ func main() {
 		pflag.PrintDefaults()
 		os.Exit(0)
 	}
-
-	internal.NewMigrator(options).MigrateAllResources()
+	resourceSet := internal.New(options.Resources,",")
+	if nil == resourceSet{
+		internal.NewMigrator(options).MigrateAllResources()
+	}
+	internal.NewMigrator(options).MigrateSomeResources(resourceSet)
 }

--- a/cmd/crd-migrator/main.go
+++ b/cmd/crd-migrator/main.go
@@ -20,7 +20,7 @@ func main() {
 		QPS:      float32(50.0),
 		Burst:    100,
 	}
-	pflag.StringVar(&options.Resources, "resources", options.LogLevel, "limit resource for migration,use plural name,separator:, e.g: pods,jobs")
+	pflag.StringVar(&options.Resources, "resources", options.LogLevel, "limit resource for migration,use plural name,separator is (e.g: pods,jobs)")
 	pflag.StringVar(&options.LogLevel, "log-level", options.LogLevel, "log level")
 	pflag.StringVar(&options.Kubeconfig, "kubeconfig", options.Kubeconfig, "path to kubeconfig file")
 	pflag.StringVar(&options.Context, "context", options.Context, "specific context to use in the kubeconfig file")

--- a/cmd/crd-migrator/main.go
+++ b/cmd/crd-migrator/main.go
@@ -20,7 +20,7 @@ func main() {
 		QPS:      float32(50.0),
 		Burst:    100,
 	}
-	pflag.StringVar(&options.Resources, "resources", options.LogLevel, "limit resource for migration,use plural name,separator is (e.g: pods,jobs)")
+	pflag.StringVar(&options.Resources, "resources", options.LogLevel, "limit resource for migration,use plural name,separator is ',' (e.g: pods,jobs)")
 	pflag.StringVar(&options.LogLevel, "log-level", options.LogLevel, "log level")
 	pflag.StringVar(&options.Kubeconfig, "kubeconfig", options.Kubeconfig, "path to kubeconfig file")
 	pflag.StringVar(&options.Context, "context", options.Context, "specific context to use in the kubeconfig file")

--- a/internal/migrator.go
+++ b/internal/migrator.go
@@ -270,6 +270,7 @@ func (m *Migrator) validateNewCRD(log logrus.FieldLogger, resource metav1.APIRes
 	return nil
 }
 
+
 func (m *Migrator) migrateOneResourceInstance(logger logrus.FieldLogger, resourceName string, item *unstructured.Unstructured) error {
 	newGVR := m.newGroupVersion.WithResource(resourceName)
 	originalNS := item.GetNamespace()

--- a/internal/set.go
+++ b/internal/set.go
@@ -3,7 +3,21 @@
 
 package internal
 
+import "strings"
+
 type stringSet map[string]struct{}
+
+func New(values, separator string) stringSet {
+	if 0 == len(values) {
+		return nil
+	}
+	array := strings.Split(values, separator)
+	set := make(stringSet)
+	for _, value := range array {
+		set.add(value)
+	}
+	return set
+}
 
 func (s stringSet) add(value string) {
 	s[value] = struct{}{}


### PR DESCRIPTION
support migration specific resources in apigruop, not all resources
```
crd-migrator --from scheduling.incubator.k8s.io/v1alpha1   --to scheduling.volcano.sh/v1beta1  --resources=podgroups  
```
it means only migrate podgroup in `scheduling.incubator.k8s.io`, without queues,jobs
and you can migrate multi crds with separator(`,`)
```
crd-migrator --from scheduling.incubator.k8s.io/v1alpha1   --to scheduling.volcano.sh/v1beta1  --resources=podgroups,queues
```
